### PR TITLE
Feat: Google 로그인 API 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Home from '@pages/Home/Home';
 
 import Login from '@pages/Login/Login';
 import KakaoRedirect from '@auth/redirects/KakaoRedirect';
+import GoogleRedirect from '@auth/redirects/GoogleRedirect';
 import SetUsername from '@pages/SetUsername/SetUsername';
 
 import SearchPost from '@pages/Search/SearchPost';
@@ -37,6 +38,7 @@ function App() {
           <Route path='/home' element={<Home />} />
           <Route path='/login' element={<Login />} />
           <Route path='/oauth' element={<KakaoRedirect />} />
+          <Route path='/oauth2' element={<GoogleRedirect />} />
           <Route path='/set-username' element={<SetUsername />} />
           <Route path='/search' element={<SearchPost />} />
           <Route path='/post/new' element={<Post />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
           <Route path='/home' element={<Home />} />
           <Route path='/login' element={<Login />} />
           <Route path='/oauth' element={<KakaoRedirect />} />
-          <Route path='/oauth2' element={<GoogleRedirect />} />
+          <Route path='/oauth/google' element={<GoogleRedirect />} />
           <Route path='/set-username' element={<SetUsername />} />
           <Route path='/search' element={<SearchPost />} />
           <Route path='/post/new' element={<Post />} />

--- a/src/auth/redirects/GoogleRedirect.tsx
+++ b/src/auth/redirects/GoogleRedirect.tsx
@@ -29,6 +29,7 @@ const GoogleRedirect = () => {
 
             // 로그인 성공 시 로컬 스토리지에 JWT 토큰 저장
             localStorage.setItem('accessToken', response.data.access_token);
+            localStorage.setItem('userID', response.data.user_id);
 
             if (response.data.username) {
               navigate('/home');

--- a/src/auth/redirects/GoogleRedirect.tsx
+++ b/src/auth/redirects/GoogleRedirect.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { postAuthCodeToServer } from '@auth/utils/authHelpers';
+
+const GoogleRedirect = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const isFirstRender = useRef<boolean>(true);
+
+  const queryParams = new URLSearchParams(location.search);
+  const GOOGLE_AUTH_CODE = queryParams.get('code');
+
+  useEffect(() => {
+    if (!isFirstRender.current) return;
+    isFirstRender.current = false;
+
+    if (GOOGLE_AUTH_CODE) {
+      console.log('Authorization Code: ', GOOGLE_AUTH_CODE);
+
+      const handleAuth = async () => {
+        try {
+          const response = await postAuthCodeToServer('GOOGLE', GOOGLE_AUTH_CODE);
+          console.log('Response: ', response);
+
+          if (response?.status === 200 || response?.status === 201) {
+            console.log('Kakao Auth Success: ', response.data);
+
+            // 로그인 성공 시 로컬 스토리지에 JWT 토큰 저장
+            localStorage.setItem('accessToken', response.data.access_token);
+
+            if (response.data.username) {
+              navigate('/home');
+            } else {
+              navigate('/set-username');
+            }
+          } else {
+            console.warn('Authorization Code POST fail');
+            navigate('/login-error');
+          }
+        } catch (error) {
+          console.error('Fetching access token failed: ', error);
+        }
+      };
+
+      handleAuth();
+    }
+  }, [GOOGLE_AUTH_CODE, navigate]);
+
+  return (
+    <>
+      <h1>Google Login Processing...</h1>
+    </>
+  );
+};
+
+export default GoogleRedirect;

--- a/src/auth/redirects/KakaoRedirect.tsx
+++ b/src/auth/redirects/KakaoRedirect.tsx
@@ -24,21 +24,22 @@ const KakaoRedirect = () => {
 
           if (response?.status === 200 || response?.status === 201) {
             console.log('Kakao Auth Success: ', response.data);
+
             // 로그인 성공 시 로컬 스토리지에 JWT 토큰 저장
             localStorage.setItem('accessToken', response.data.access_token);
-          } else if (response?.status === 401) {
-            console.warn('Authorization Code POST fail');
-          }
+            localStorage.setItem('userID', response.data.user_id);
 
-          if (response?.status === 200 && response.data.username) {
-            navigate('/home');
+            if (response.data.username) {
+              navigate('/home');
+            } else {
+              navigate('/set-username');
+            }
           } else {
-            navigate('/set-username');
+            console.warn('Authorization Code POST fail');
+            navigate('/login-error');
           }
         } catch (error) {
           console.error('Unknown Kakao Auth Error: ', error);
-          // // 에러 처리 페이지로 라우팅
-          // navigate('/login-error');
         }
       };
 

--- a/src/auth/utils/authHelpers.ts
+++ b/src/auth/utils/authHelpers.ts
@@ -33,6 +33,6 @@ export const postAuthCodeToServer = async (
 
     return { status: response.status, data: response.data };
   } catch (error) {
-    console.error('Kakao Auth Error:', error);
+    console.error('OAuth 2.0 Error:', error);
   }
 };

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -11,10 +11,20 @@ const Login: React.FC = () => {
   const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
   const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
+  const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+  const GOOGLE_REDIRECT_URI = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
+
   const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}`;
+
+  const GoogleAuthBaseURL = 'https://accounts.google.com/o/oauth2/v2/auth';
+  const GOOGLE_AUTH_URL = `${GoogleAuthBaseURL}?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=openid%20profile%20email`;
 
   const handleKakaoLogin = () => {
     window.location.href = KAKAO_AUTH_URL;
+  };
+
+  const handleGoogleLogin = () => {
+    window.location.href = GOOGLE_AUTH_URL;
   };
 
   return (
@@ -32,7 +42,7 @@ const Login: React.FC = () => {
           네이버로 로그인
           <S.NaverIcon src={NaverIcon} />
         </S.NaverButton>
-        <S.GoogleButton>
+        <S.GoogleButton onClick={handleGoogleLogin}>
           구글로 로그인
           <S.SocialIcon src={GoogleIcon} />
         </S.GoogleButton>


### PR DESCRIPTION
## Tasks Done

1. 구글 로그인 버튼 클릭 시, Google OAuth 2.0 서버로의 Redirection
2. 애플리케이션 서버로의 Authorization Code(인가 코드) `POST`
3. 로컬 스토리지에 `access_token` 및 `user_id` 저장

## Hardship
3개의 소셜 로그인을 하나의 애플리케이션에 통합하는 상황에서,
서버 사이드에서 `http://localhost:3000/oauth` 라는 하나의 Redirect URI에 대해서만
Authorizaiton code `POST` 요청이 허용되어 있어서 여러 개의 소셜 로그인을 통합하는 과정에서 원인을 찾기 어려웠음

### Solution

1. 각 소셜 로그인 별로 Redirect URI를 `/oauth/kakao`, `/oauth/google`, `/oauth/naver` 와 같이 구분할 것
2. 서버 사이드에서 이 3개의 URI에 대한 `POST` 요청을 허용하도록 수정 요청

## Remaing Tasks

- [ ] 카카오 로그인 Redirect URI `/oauth/kakao` 로 변경
- [ ] 닉네임 API 구현 후, 로컬 스토리지에 `username` 저장

## Related Issues
#33 