### PR TITLE
Feat: 로그아웃 및 Access Token 재발급 API 구현

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -11,12 +11,47 @@ axiosInstance.interceptors.request.use(
 
     // 토큰이 존재하면 토큰을 Authorization 헤더에 추가
     if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
     }
     return config;
   },
   (error) => {
-    return Promise.reject(error); // 요청 중 오류 발생 시 거부
+    return Promise.reject(error); // 에러 발생 시 상위 코드에서 에러 처리
+  },
+);
+
+// Response Interceptors
+axiosInstance.interceptors.response.use(
+  (response) => response, //  axios 요청 성공 시
+  async (error) => {
+    // axios 요청에 사용된 config object (URL, headers, body 포함)
+    const originalRequest = error.config;
+
+    // !originalRequest._retry는 요청 실패 시, 최초 한번만 재시도하도록 제어하는 역할
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        // Access Token 재발급 요청
+        const { data } = await axiosInstance.post('/auth/token_reissue');
+
+        const accessToken = data.access_token;
+        console.log('New Access Token', accessToken);
+
+        if (accessToken) {
+          localStorage.setItem('accessToken', accessToken);
+
+          originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+          return axiosInstance(originalRequest);
+        }
+      } catch {
+        // Access Token 재발급 실패 시
+        localStorage.removeItem('accessToken');
+        window.location.href = '/login';
+        console.error('Access Token reissue failed: ', error);
+      }
+    }
+    return Promise.reject(error);
   },
 );
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,8 +1,22 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
+
+let isTokenRefreshing = false; // 토큰 재발급 여부를 관리하는 전역 상태
+let refreshSubscribers: ((token: string) => void)[] = []; // 재발급 완료 후 대기 중인 요청 처리
+
+// 재발급된 토큰을 다른 요청에 전달
+const onTokenRefreshed = (newToken: string) => {
+  refreshSubscribers.forEach((callback) => callback(newToken));
+  refreshSubscribers = []; // 대기 목록 초기화
+};
+
+// 재발급 요청 중 다른 요청을 대기열에 추가
+const addRefreshSubscriber = (callback: (token: string) => void) => {
+  refreshSubscribers.push(callback);
+};
 
 // 요청 인터셉터 (Request Interceptor)
 axiosInstance.interceptors.request.use(
@@ -11,7 +25,7 @@ axiosInstance.interceptors.request.use(
 
     // 토큰이 존재하면 토큰을 Authorization 헤더에 추가
     if (accessToken) {
-      config.headers['Authorization'] = `Bearer ${accessToken}`;
+      config.headers.Authorization = `Bearer ${accessToken}`;
     }
     return config;
   },
@@ -22,33 +36,50 @@ axiosInstance.interceptors.request.use(
 
 // Response Interceptors
 axiosInstance.interceptors.response.use(
-  (response) => response, //  axios 요청 성공 시
+  (response: AxiosResponse) => response, //  axios 요청 성공 시
   async (error) => {
     // axios 요청에 사용된 config object (URL, headers, body 포함)
     const originalRequest = error.config;
 
-    // !originalRequest._retry는 요청 실패 시, 최초 한번만 재시도하도록 제어하는 역할
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (error.response?.status === 403 && !originalRequest._retry) {
+      if (isTokenRefreshing) {
+        // 토큰 재발급 중일 경우 대기
+        return new Promise((resolve) => {
+          addRefreshSubscriber((newToken: string) => {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            resolve(axiosInstance(originalRequest));
+          });
+        });
+      }
+
+      // 최초로 토큰 재발급 요청 실행
       originalRequest._retry = true;
+      isTokenRefreshing = true;
 
       try {
         // Access Token 재발급 요청
         const { data } = await axiosInstance.post('/auth/token_reissue');
+        console.log(data);
 
-        const accessToken = data.access_token;
-        console.log('New Access Token', accessToken);
+        const newAccessToken = data.access_token;
+        console.log('New Access Token', newAccessToken);
 
-        if (accessToken) {
-          localStorage.setItem('accessToken', accessToken);
+        if (newAccessToken) {
+          localStorage.setItem('accessToken', newAccessToken);
 
-          originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+          // 대기 중인 요청들에 새 토큰 전달
+          onTokenRefreshed(newAccessToken);
+
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
           return axiosInstance(originalRequest);
         }
       } catch {
         // Access Token 재발급 실패 시
         localStorage.removeItem('accessToken');
         window.location.href = '/login';
-        console.error('Access Token reissue failed: ', error);
+        return Promise.reject(error);
+      } finally {
+        isTokenRefreshing = false;
       }
     }
     return Promise.reject(error);

--- a/src/auth/redirects/GoogleRedirect.tsx
+++ b/src/auth/redirects/GoogleRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { postAuthCodeToServer } from '@auth/utils/authHelpers';
+
 import Spinner from '@components/postdetail/Spinner';
 
 const GoogleRedirect = () => {

--- a/src/auth/redirects/KakaoRedirect.tsx
+++ b/src/auth/redirects/KakaoRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { postAuthCodeToServer } from '@auth/utils/authHelpers';
+
 import Spinner from '@components/postdetail/Spinner';
 
 const KakaoRedirect = () => {

--- a/src/auth/redirects/NaverRedirect.tsx
+++ b/src/auth/redirects/NaverRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { postAuthCodeToServer } from '@auth/utils/authHelpers';
+
 import Spinner from '@components/postdetail/Spinner';
 
 const NaverRedirect = () => {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,19 +1,26 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import * as S from './Header.Styled';
+
+import useAuth from '@hooks/useAuth';
+
 import LoginModalContainer from '@components/home/LoginModalContainer';
 import { LogoutModal } from '@components/modal/LogoutModal';
 import { TipZipLogo } from '@components/Icons/TipZipLogo';
-import useAuth from '@hooks/useAuth';
+
+import * as S from './Header.Styled';
 
 const Header: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, validateToken, logout } = useAuth();
 
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
   const logoColor = location.pathname === '/mypage' ? 'black' : '';
+
+  useEffect(() => {
+    validateToken();
+  }, [validateToken]);
 
   const handleLogoutClick = () => {
     setShowLogoutModal(true);
@@ -22,17 +29,21 @@ const Header: React.FC = () => {
     setShowLogoutModal(false);
   };
   const handleLogout = () => {
-    // 로그아웃 로직을 여기에 추가
-    setShowLogoutModal(false);
+    // React hook useAuth 내 logout 함수 호출
+    logout();
+    window.location.href = '/home';
   };
 
-  const handleLoginRequired = (callback: () => void) => {
-    if (isAuthenticated) {
-      callback();
-    } else {
-      setShowLoginModal(true); // 로그인되지 않았으면 로그인 모달 띄우기
-    }
-  };
+  const handleLoginRequired = useCallback(
+    (callback: () => void) => {
+      if (isAuthenticated) {
+        callback();
+      } else {
+        setShowLoginModal(true); // 로그인되지 않았으면 로그인 모달 띄우기
+      }
+    },
+    [isAuthenticated],
+  );
 
   const handleProfileClick = () => {
     handleLoginRequired(() => navigate('/mypage')); // 로그인 후 마이페이지로 이동

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -31,6 +31,7 @@ const Header: React.FC = () => {
   const handleLogout = () => {
     // React hook useAuth 내 logout 함수 호출
     logout();
+    setShowLogoutModal(false);
     window.location.href = '/home';
   };
 

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,14 +1,30 @@
-import { useState, useEffect } from 'react';
+import axiosInstance from '@api/axios';
+import { useState, useCallback } from 'react';
 
 const useAuth = () => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
 
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    setIsAuthenticated(!!token);
+  const validateToken = (): boolean => {
+    const accessToken = localStorage.getItem('accessToken');
+    const isValid = !!accessToken;
+    setIsAuthenticated(isValid);
+    return isValid;
+  };
+
+  const logout = useCallback(async (): Promise<void> => {
+    try {
+      // DB 내 Refresh Token 삭제
+      await axiosInstance.post('/auth/logout');
+
+      // 로컬 스토리지 내 모든 데이터 삭제
+      localStorage.clear();
+      setIsAuthenticated(false);
+    } catch (error) {
+      console.error('Logout failed: ', error);
+    }
   }, []);
 
-  return { isAuthenticated };
+  return { isAuthenticated, validateToken, logout };
 };
 
 export default useAuth;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -14,10 +14,16 @@ const useAuth = () => {
   const logout = useCallback(async (): Promise<void> => {
     try {
       // DB 내 Refresh Token 삭제
-      await axiosInstance.post('/auth/logout');
+      const response = await axiosInstance.post('/auth/logout');
+
+      if (response.status === 200) {
+        console.log('Refresh Token removed: ', response);
+      }
 
       // 로컬 스토리지 내 모든 데이터 삭제
       localStorage.clear();
+
+      // isAuthenticated 로그인 관리 State 업데이트
       setIsAuthenticated(false);
     } catch (error) {
       console.error('Logout failed: ', error);


### PR DESCRIPTION
## Tasks Done

- 로그아웃 API 구현 (`useAuth` 내 `logout` 함수 호출)
- `logout` 함수 내 Refresh token 삭제 API 요청 후, `isAuthenticated` 상태 변경 
- `logout` 함수 처리 후, 로그아웃 모달 상태 변경 후 `/home`으로 라우팅

## Related Issues

#42 